### PR TITLE
Add `SameSite=Strict` and a `Max-Age` of 90 days

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.9.0-alpha.3"
 base64 = "0.11"
 conduit = "0.9.0-alpha.2"
 conduit-middleware = "0.9.0-alpha.2"
+time = { version = "0.2", default-features = false }
 
 [dependencies.cookie]
 features = ["secure"]

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,9 +4,11 @@ use std::str;
 
 use conduit::RequestExt;
 use conduit_middleware::{AfterResult, BeforeResult};
-use cookie::{Cookie, Key};
+use cookie::{Cookie, Key, SameSite};
 
 use super::RequestCookies;
+
+const MAX_AGE_DAYS: i64 = 90;
 
 pub struct SessionMiddleware {
     cookie_name: String,
@@ -79,6 +81,8 @@ impl conduit_middleware::Middleware for SessionMiddleware {
             Cookie::build(self.cookie_name.to_string(), encoded)
                 .http_only(true)
                 .secure(self.secure)
+                .same_site(SameSite::Strict)
+                .max_age(time::Duration::days(MAX_AGE_DAYS))
                 .path("/")
                 .finish()
         };


### PR DESCRIPTION
These values are hard-coded for crates.io. If other use cases need to
tweak these settings, we can add the ability to customize this behavior
at that time.

r? @JohnTitor
cc rust-lang/crates.io#2480
Fixes: #12