### PR TITLE
session: Remove unused `&self` from `encode/decode()` functions

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -67,7 +67,7 @@ impl conduit_middleware::Middleware for SessionMiddleware {
         let session = {
             let jar = req.cookies_mut().signed(&self.key);
             jar.get(&self.cookie_name)
-                .map(|cookie| Self::decode(cookie))
+                .map(Self::decode)
                 .unwrap_or_else(HashMap::new)
         };
         req.mut_extensions().insert(Session {


### PR DESCRIPTION
These functions don't need `self`, so we can remove it to make them easier to use.

This is somewhat related to https://github.com/rust-lang/crates.io/pull/3280 :)