### PR TITLE
Upgrade `cookie` dep to 0.16.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,10 @@ version = "0.9.0-alpha.5"
 base64 = "0.13"
 conduit = "0.9.0-alpha.5"
 conduit-middleware = "0.9.0-alpha.4"
-time = { version = "0.2", default-features = false }
 
 [dependencies.cookie]
 features = ["secure"]
-version = "0.15"
+version = "0.16.0-rc.1"
 
 [dev-dependencies]
 conduit-test = "0.9.0-alpha.5"

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,7 +4,7 @@ use std::str;
 
 use conduit::RequestExt;
 use conduit_middleware::{AfterResult, BeforeResult};
-use cookie::{Cookie, Key, SameSite};
+use cookie::{time::Duration, Cookie, Key, SameSite};
 
 use super::RequestCookies;
 
@@ -86,7 +86,7 @@ impl conduit_middleware::Middleware for SessionMiddleware {
                 .http_only(true)
                 .secure(self.secure)
                 .same_site(SameSite::Strict)
-                .max_age(time::Duration::days(MAX_AGE_DAYS))
+                .max_age(Duration::days(MAX_AGE_DAYS))
                 .path("/")
                 .finish();
             req.cookies_mut().signed_mut(&self.key).add(cookie);


### PR DESCRIPTION
Changelog: https://github.com/SergioBenitez/cookie-rs/blob/master/CHANGELOG.md#version-0160-rc1-aug-19-2021
Now we can use the re-exported `time` from `cookie`.
Closes #26