### PR TITLE
Bump MSRV up to 1.57.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # minimum supported rust version
-  MSRV: 1.51.0
+  MSRV: 1.57.0
 
 jobs:
   check:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "conduit-cookie"
 repository = "https://github.com/conduit-rust/conduit-cookie"
 version = "0.10.0"
 edition = "2018"
-rust-version = "1.51.0"
+rust-version = "1.57.0"
 
 [dependencies]
 base64 = "0.13"


### PR DESCRIPTION
time crate requires >= 1.57.0.
Signed-off-by: Yuki Okushi <jtitor@2k36.org>